### PR TITLE
perf: readAllBatch 2バッチ化（4→2ラウンドトリップ）

### DIFF
--- a/internal/obd/pids.go
+++ b/internal/obd/pids.go
@@ -188,26 +188,43 @@ func (r *Reader) readAllBatch() (*OBDData, error) {
 		parsePID(data, pid, raw)
 	}
 
-	// 冷却水温
+	// バッチ2: 水温 + MAP + MAF（対応PIDのみ動的に構築）
+	batch2 := []byte{PIDCoolantTemp}
+	if r.hasMAP {
+		batch2 = append(batch2, PIDIntakeMAP)
+	}
+	if r.hasMAF {
+		batch2 = append(batch2, PIDMAFAirFlow)
+	}
+
+	result2, err := r.dev.QueryMultiPID(batch2)
+	if err != nil {
+		// バッチ2失敗時は個別クエリにフォールバック
+		r.readBatch2Fallback(data)
+		return data, nil
+	}
+	for pid, raw := range result2 {
+		parsePID(data, pid, raw)
+	}
+
+	return data, nil
+}
+
+// readBatch2Fallback はバッチ2失敗時に個別クエリで水温・MAP・MAFを取得する
+func (r *Reader) readBatch2Fallback(data *OBDData) {
 	if raw, err := r.dev.QueryPID(PIDCoolantTemp); err == nil {
 		parsePID(data, PIDCoolantTemp, raw)
 	}
-
-	// インマニ圧（MAP）
 	if r.hasMAP {
 		if raw, err := r.dev.QueryPID(PIDIntakeMAP); err == nil {
 			parsePID(data, PIDIntakeMAP, raw)
 		}
 	}
-
-	// MAFエアフロー（燃費計算用）
 	if r.hasMAF {
 		if raw, err := r.dev.QueryPID(PIDMAFAirFlow); err == nil {
 			parsePID(data, PIDMAFAirFlow, raw)
 		}
 	}
-
-	return data, nil
 }
 
 // readAllSingle は従来の個別PIDクエリで読み取る（フォールバック）

--- a/internal/obd/reader_test.go
+++ b/internal/obd/reader_test.go
@@ -348,3 +348,143 @@ func TestReadAll_MAPOnly(t *testing.T) {
 		t.Errorf("MAF should be 0 when not supported, got %.2f", data.MAFAirFlow)
 	}
 }
+
+// --- ReadAll 2バッチ化テスト ---
+
+func TestReadAll_2Batch_VerifyBatchCount(t *testing.T) {
+	// マルチPID対応 + MAP + MAF → QueryMultiPIDが2回呼ばれることを検証
+	dev := newMockDevice()
+	dev.pidResponses[PIDEngineRPM] = []byte{0x1A, 0x20}
+	dev.pidResponses[PIDVehicleSpeed] = []byte{60}
+	dev.pidResponses[PIDEngineLoad] = []byte{128}
+	dev.pidResponses[PIDThrottlePosition] = []byte{64}
+	dev.pidResponses[PIDCoolantTemp] = []byte{130}
+	dev.pidResponses[PIDIntakeMAP] = []byte{80}
+	dev.pidResponses[PIDMAFAirFlow] = []byte{0x01, 0xF4}
+
+	r := &Reader{dev: dev, supportsMulti: true, multiTested: true, hasMAF: true, hasMAP: true}
+	data, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	// QueryMultiPIDは2回（バッチ1 + バッチ2）
+	if dev.multiCalls != 2 {
+		t.Errorf("QueryMultiPID calls: got %d, want 2", dev.multiCalls)
+	}
+
+	// 全データが取得できている
+	if data.CoolantTemp != 90 {
+		t.Errorf("Coolant: got %.0f, want 90", data.CoolantTemp)
+	}
+	if data.IntakeMAP != 80 {
+		t.Errorf("MAP: got %.0f, want 80", data.IntakeMAP)
+	}
+	if data.MAFAirFlow != 5.0 {
+		t.Errorf("MAF: got %.2f, want 5.0", data.MAFAirFlow)
+	}
+}
+
+func TestReadAll_2Batch_MAPOnly_NoBatchCount(t *testing.T) {
+	// MAP対応・MAF非対応 → バッチ2は [水温, MAP] の2PID
+	dev := newMockDevice()
+	dev.pidResponses[PIDEngineRPM] = []byte{0x1A, 0x20}
+	dev.pidResponses[PIDVehicleSpeed] = []byte{60}
+	dev.pidResponses[PIDEngineLoad] = []byte{128}
+	dev.pidResponses[PIDThrottlePosition] = []byte{64}
+	dev.pidResponses[PIDCoolantTemp] = []byte{130}
+	dev.pidResponses[PIDIntakeMAP] = []byte{80}
+
+	r := &Reader{dev: dev, supportsMulti: true, multiTested: true, hasMAP: true, hasMAF: false}
+	data, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if dev.multiCalls != 2 {
+		t.Errorf("QueryMultiPID calls: got %d, want 2", dev.multiCalls)
+	}
+	if data.CoolantTemp != 90 {
+		t.Errorf("Coolant: got %.0f, want 90", data.CoolantTemp)
+	}
+	if data.IntakeMAP != 80 {
+		t.Errorf("MAP: got %.0f, want 80", data.IntakeMAP)
+	}
+	if data.MAFAirFlow != 0 {
+		t.Errorf("MAF should be 0: got %.2f", data.MAFAirFlow)
+	}
+}
+
+func TestReadAll_2Batch_CoolantOnly(t *testing.T) {
+	// MAP・MAF両方非対応 → バッチ2は [水温] のみ
+	dev := newMockDevice()
+	dev.pidResponses[PIDEngineRPM] = []byte{0x1A, 0x20}
+	dev.pidResponses[PIDVehicleSpeed] = []byte{60}
+	dev.pidResponses[PIDEngineLoad] = []byte{128}
+	dev.pidResponses[PIDThrottlePosition] = []byte{64}
+	dev.pidResponses[PIDCoolantTemp] = []byte{130}
+
+	r := &Reader{dev: dev, supportsMulti: true, multiTested: true, hasMAP: false, hasMAF: false}
+	data, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if dev.multiCalls != 2 {
+		t.Errorf("QueryMultiPID calls: got %d, want 2", dev.multiCalls)
+	}
+	if data.CoolantTemp != 90 {
+		t.Errorf("Coolant: got %.0f, want 90", data.CoolantTemp)
+	}
+}
+
+func TestReadAll_2Batch_Batch2Fallback(t *testing.T) {
+	// バッチ2が失敗 → 個別クエリにフォールバック
+	dev := newMockDevice()
+	dev.pidResponses[PIDEngineRPM] = []byte{0x1A, 0x20}
+	dev.pidResponses[PIDVehicleSpeed] = []byte{60}
+	dev.pidResponses[PIDEngineLoad] = []byte{128}
+	dev.pidResponses[PIDThrottlePosition] = []byte{64}
+	dev.pidResponses[PIDCoolantTemp] = []byte{130}
+	dev.pidResponses[PIDIntakeMAP] = []byte{80}
+
+	// バッチ2だけ失敗させるため、カウントベースのフック
+	batch2Fails := &batch2FailDevice{mockDevice: dev, failOnCall: 2}
+
+	r := &Reader{dev: batch2Fails, supportsMulti: true, multiTested: true, hasMAP: true, hasMAF: false}
+	data, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	// バッチ1は成功、バッチ2は失敗してフォールバック
+	if data.SpeedKmh != 60 {
+		t.Errorf("Speed: got %.0f, want 60", data.SpeedKmh)
+	}
+	if data.CoolantTemp != 90 {
+		t.Errorf("Coolant (fallback): got %.0f, want 90", data.CoolantTemp)
+	}
+	if data.IntakeMAP != 80 {
+		t.Errorf("MAP (fallback): got %.0f, want 80", data.IntakeMAP)
+	}
+
+	// supportsMulti はまだ true（バッチ1は成功しているため）
+	if !r.supportsMulti {
+		t.Error("supportsMulti should remain true (batch1 succeeded)")
+	}
+}
+
+// batch2FailDevice は N 回目の QueryMultiPID を失敗させるラッパー
+type batch2FailDevice struct {
+	*mockDevice
+	failOnCall int
+	callCount  int
+}
+
+func (d *batch2FailDevice) QueryMultiPID(pids []byte) (map[byte][]byte, error) {
+	d.callCount++
+	if d.callCount == d.failOnCall {
+		return nil, fmt.Errorf("バッチ2失敗")
+	}
+	return d.mockDevice.QueryMultiPID(pids)
+}


### PR DESCRIPTION
## Summary
- `readAllBatch()` の水温・MAP・MAFを個別クエリから2番目のマルチPIDバッチに統合
- ReadAll のラウンドトリップを **4回→2回** に削減（推定 60〜200ms 短縮）
- バッチ2失敗時は個別クエリにフォールバック（既存動作を維持）

## 変更内容
| ファイル | 変更 |
|---|---|
| `internal/obd/pids.go` | `readAllBatch()` を2バッチ化 + `readBatch2Fallback()` 追加 |
| `internal/obd/reader_test.go` | 2バッチ検証テスト4件追加 |

### Before (4 ラウンドトリップ)
```
通信1: QueryMultiPID([RPM, Speed, Load, Throttle])
通信2: QueryPID(CoolantTemp)
通信3: QueryPID(IntakeMAP)       ← MAP対応車のみ
通信4: QueryPID(MAFAirFlow)      ← MAF対応車のみ
```

### After (2 ラウンドトリップ)
```
通信1: QueryMultiPID([RPM, Speed, Load, Throttle])
通信2: QueryMultiPID([CoolantTemp, IntakeMAP, MAFAirFlow])  ← 動的構築
```

## Test plan
- [x] mock テスト PASS（バッチ数検証・各構成・フォールバック）
- [x] `go vet` / `go test -race` PASS
- [x] ARM64 クロスコンパイル PASS
- [ ] **実車テスト（DYデミオ）でマルチPIDバッチ2の安定性確認**
- [ ] 不安定な場合は revert

> **Draft**: 実車テスト完了後に Ready にします

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)