### PR TITLE
Release v0.3.6

### DIFF
--- a/cmd/pi-obd-meter/app.go
+++ b/cmd/pi-obd-meter/app.go
@@ -263,8 +263,12 @@ func (app *App) restoreFromGAS(ctx context.Context) {
 	if restored.LastRefuelKm > 0 && restored.TotalKm > restored.LastRefuelKm {
 		tripKm := restored.TotalKm - restored.LastRefuelKm
 		localTrip := app.tracker.DistanceKm()
-		// GAS側のほうが大きい場合のみ補正（ローカルが進んでいる場合は上書きしない）
-		if tripKm > localTrip {
+		if localTrip == 0 {
+			// ローカルが0 = 給油リセット済み。GASからの復元をスキップ。
+			// 次回メンテナンス送信で last_refuel_km が同期される。
+			slog.Info("ローカルトリップ0、GAS復元スキップ", "gas_trip_km", tripKm)
+		} else if tripKm > localTrip {
+			// GAS側のほうが大きい場合のみ補正（ローカルが進んでいる場合は上書きしない）
 			app.tracker.SetDistance(tripKm)
 			slog.Info("GASからトリップ復元", "trip_km", tripKm, "last_refuel_km", restored.LastRefuelKm)
 		}

--- a/configs/config.json
+++ b/configs/config.json
@@ -14,7 +14,7 @@
   "fuel_tank_l": 40,
   "fuel_rate_correction": 1.3,
   "eco_green_kmpl": 6,
-  "eco_orange_kmpl": 2,
+  "eco_orange_kmpl": 3,
   "maintenance_reminders": [
     { "id": "oil_change", "name": "エンジンオイル交換", "type": "distance", "interval_km": 3000, "warning_pct": 0.8, "last_reset_km": 97000 },
     { "id": "air_filter", "name": "エアフィルター交換", "type": "distance", "interval_km": 20000, "warning_pct": 0.85, "last_reset_km": 80000 },

--- a/gas/webhook.gs
+++ b/gas/webhook.gs
@@ -86,6 +86,10 @@ function handleMaintenance(data) {
   }
   if (data.trip_km >= 0) {
     upsertSetting('trip_km', data.trip_km);
+    // last_refuel_km を常に同期（Pi再起動時のトリップ復元ズレ防止）
+    if (data.total_km > 0) {
+      upsertSetting('last_refuel_km', data.total_km - data.trip_km);
+    }
   }
 
   // ODO補正適用確認: Piが補正を適用したら設定をクリア

--- a/internal/obd/elm327.go
+++ b/internal/obd/elm327.go
@@ -97,7 +97,7 @@ func (e *ELM327) connectInternal() error {
 	for _, cmd := range initCmds {
 		resp, err := e.sendCommand(cmd)
 		if err != nil {
-			_ = e.port.Close()
+			_ = port.Close()
 			e.port = nil
 			return fmt.Errorf("初期化コマンド %s 失敗: %w", cmd, err)
 		}


### PR DESCRIPTION
## Release v0.3.6

### Changes since v0.3.1

- fix: 給油後トリップリセット不具合修正 + ELM327 panic修正
- feat: ECO閾値をconfig化 + TEMP閾値調整
- fix: ineffassign lint error blocking CI deploy
- fix: CAN キャプチャ保存先を /opt に変更
- fix: CAN キャプチャスクリプトの初期化とフィルタ修正
- feat: CAN キャプチャスクリプト + テスト手順書
- refactor: 冗長なfuelRateLH<0.01エンブレ判定を削除
- docs: ECO閾値ドキュメントを現行ロジックに更新
- fix: ECO橙/赤閾値を緩和 (10→6.2 km/L) + JS fallback統一
- fix: GASトリップ補正UX改善 + メーターフリーズ防止
- fix: ECO閾値調整 — green≥15/orange≥5/red<5 + エンブレ緑に戻す
- fix: Pi→GAS トリップ同期 — trip_km をペイロードに追加
- fix: GASからトリップ距離復元 + ドキュメント更新
- feat: ECO表示改善 — ReadFast即時判定・エンブレ消灯・UI簡素化
- feat: ELM327接続改善 — タイムアウト追加・ReadFast 2PID化・200msポーリング
- docs: メーター表示指標ガイドを追加
- ui: トリップ補正をメンテの上に移動 + ボタン色入れ替え
- feat: トリップ補正機能（リセット→補正に変更） #51
- test: カバレッジ強化（app.go, sender, trip）
- fix: obd_loop_test.go のlintエラー修正（未使用モック削除・ineffassign解消）
- refactor: OBD読み取りをgoroutine+channelに分離 (#37)
- ci: Claude Code Review ワークフロー削除
- feat: Claude Code Review を実用的なゲートに改善
- fix: Claude Code Review に actions/checkout ステップ追加
- fix: release.sh の自動バージョン計算を全タグ対象に修正
- fix: reader_test.go の gofmt フォーマット修正
- fix: Claude Code Review に id-token: write パーミッション追加
- feat: ダッシュボードに走行統計カード + トリップリセット機能追加
- test: obd Readerテスト追加 + GAS給油ログの未使用カラム削除
- fix: release.sh で必須チェックのみ待機（--required）
- fix: release.sh が dev-latest タグを拾う問題を修正
- ci: リリース戦略改善 — 冪等スクリプト・PRリリースノート・Pi自動ロールバック
- refactor: コード品質改善 — ArcAnimator抽出・obdState構造体化・errcheck導入
- docs: ドキュメント全面整備 — 実態との乖離修正 + 構造分割
- docs: キオスク終了を「画面3秒長押し」に修正
- ci: mainブランチ保護 + PRベースリリースフロー
- docs: Wi-Fiトラブルシューティングガイド追加
- ci: CI成功時のみdevデプロイを実行
- feat: RPMインジケーター追加 + gofmtエラー修正
- feat: RPMインジケーター追加（SEND削除）
- feat: MAP・燃料レートアーク追加 + UI改善
- feat: インマニ圧(MAP)センサー対応 — 表示・燃費推定・エンブレ判定
- fix: configバリデーション・ヘルスチェック強化・テスト拡充・ログ改善
- chore: 不要コード削除 + ドキュメント更新
- refactor: EMA平滑化を全て除去し生値を使用（スパイク除去は維持）
- fix: 燃費表示の精度改善 — レート補正係数追加・EMA修正・速度0表示
- fix: シミュレーションモードがAPI復帰後も停止しない問題を修正
- perf: メーターUI応答性改善 — LERP速度・CSS遷移を高速化
- fix: トリップ状態保存を距離ベース(0.1km)に変更し電源断での距離ロスを低減
- fix: スロットルアークのスケーリング修正（ベタ踏みで最大到達）
- refactor: 車種依存の閾値をconfig化・排気量連動化
- fix: OBD全値にスパイク除去+EMA平滑化フィルター追加
- feat: タッチパネルからキオスク終了 + WiFi未接続時キオスク抑止
- feat: Claude Codeスキル追加 + 燃費EMAスムージング + ポーリング200ms復帰
- docs: 算出ロジック・閾値一覧を追加
- feat: Pi自動デプロイ（develop push → 2分以内に自動更新）
- ci: GASデプロイをdevelopブランチでも実行
- fix: エンブレ判定改善 + ECO>30で平均燃費表示 + TEMP閾値変更
- feat: develop/mainブランチ戦略を導入
- fix: golangci-lint v2移行（CI Go 1.25対応）

---
Auto-generated by `make release`