### PR TITLE
Release v1.0.3

### DIFF
--- a/cmd/pi-obd-meter/api.go
+++ b/cmd/pi-obd-meter/api.go
@@ -93,6 +93,14 @@ func (app *App) startLocalAPI(ctx context.Context) {
 			ecoKmplOrange = app.cfg.EcoOrangeKmpl
 		}
 		estRange := app.cfg.FuelTankL * ecoKmplGreen
+		tripWarnKm := math.Round(estRange * 0.5)
+		tripDangerKm := math.Round(estRange * 0.85)
+		if app.cfg.TripWarnKm > 0 {
+			tripWarnKm = app.cfg.TripWarnKm
+		}
+		if app.cfg.TripDangerKm > 0 {
+			tripDangerKm = app.cfg.TripDangerKm
+		}
 		writeJSON(w, configResponse{
 			MaxSpeedKmh:     app.cfg.MaxSpeedKmh,
 			Version:         version,
@@ -102,8 +110,8 @@ func (app *App) startLocalAPI(ctx context.Context) {
 			ThrottleMaxPct:  app.cfg.ThrottleMaxPct,
 			EcoKmplGreen:    ecoKmplGreen,
 			EcoKmplOrange:   ecoKmplOrange,
-			TripWarnKm:      math.Round(estRange * 0.5),
-			TripDangerKm:    math.Round(estRange * 0.85),
+			TripWarnKm:      tripWarnKm,
+			TripDangerKm:    tripDangerKm,
 		})
 	})
 

--- a/cmd/pi-obd-meter/config.go
+++ b/cmd/pi-obd-meter/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	FuelRateCorrection   float64                  `json:"fuel_rate_correction"`
 	EcoGreenKmpl         float64                  `json:"eco_green_kmpl"`
 	EcoOrangeKmpl        float64                  `json:"eco_orange_kmpl"`
+	TripWarnKm           float64                  `json:"trip_warn_km"`
+	TripDangerKm         float64                  `json:"trip_danger_km"`
 	MaintenanceReminders []maintenance.Reminder   `json:"maintenance_reminders"`
 	Brightness           display.BrightnessConfig `json:"brightness"`
 }

--- a/configs/config.json
+++ b/configs/config.json
@@ -15,6 +15,8 @@
   "fuel_rate_correction": 1.3,
   "eco_green_kmpl": 6,
   "eco_orange_kmpl": 6,
+  "trip_warn_km": 300,
+  "trip_danger_km": 400,
   "maintenance_reminders": [
     { "id": "oil_change", "name": "エンジンオイル交換", "type": "distance", "interval_km": 3000, "warning_pct": 0.8, "last_reset_km": 97000 },
     { "id": "air_filter", "name": "エアフィルター交換", "type": "distance", "interval_km": 20000, "warning_pct": 0.85, "last_reset_km": 80000 },


### PR DESCRIPTION
## Release v1.0.3

### Changes since v0.3.1

- feat: TRIP閾値をconfig.jsonで直接設定可能に
- fix: キオスク起動前にWiFi接続を待機（ループ）
- fix: キオスク終了後10秒で自動復帰 (Restart=always)
- fix: WiFiガードを削除してキオスク常時起動に変更
- feat: ECOランプ改善 — エンブレ=緑、>=6黄、<6赤 + オレンジを黄色に変更
- fix: 給油後トリップリセット不具合修正 + ELM327 panic修正
- feat: ECO閾値をconfig化 + TEMP閾値調整
- fix: ineffassign lint error blocking CI deploy
- fix: CAN キャプチャ保存先を /opt に変更
- fix: CAN キャプチャスクリプトの初期化とフィルタ修正
- feat: CAN キャプチャスクリプト + テスト手順書
- refactor: 冗長なfuelRateLH<0.01エンブレ判定を削除
- docs: ECO閾値ドキュメントを現行ロジックに更新
- fix: ECO橙/赤閾値を緩和 (10→6.2 km/L) + JS fallback統一
- fix: GASトリップ補正UX改善 + メーターフリーズ防止
- fix: ECO閾値調整 — green≥15/orange≥5/red<5 + エンブレ緑に戻す
- fix: Pi→GAS トリップ同期 — trip_km をペイロードに追加
- fix: GASからトリップ距離復元 + ドキュメント更新
- feat: ECO表示改善 — ReadFast即時判定・エンブレ消灯・UI簡素化
- feat: ELM327接続改善 — タイムアウト追加・ReadFast 2PID化・200msポーリング
- docs: メーター表示指標ガイドを追加
- ui: トリップ補正をメンテの上に移動 + ボタン色入れ替え
- feat: トリップ補正機能（リセット→補正に変更） #51
- test: カバレッジ強化（app.go, sender, trip）
- fix: obd_loop_test.go のlintエラー修正（未使用モック削除・ineffassign解消）
- refactor: OBD読み取りをgoroutine+channelに分離 (#37)
- ci: Claude Code Review ワークフロー削除
- feat: Claude Code Review を実用的なゲートに改善
- fix: Claude Code Review に actions/checkout ステップ追加
- fix: release.sh の自動バージョン計算を全タグ対象に修正
- fix: reader_test.go の gofmt フォーマット修正
- fix: Claude Code Review に id-token: write パーミッション追加
- feat: ダッシュボードに走行統計カード + トリップリセット機能追加
- test: obd Readerテスト追加 + GAS給油ログの未使用カラム削除
- fix: release.sh で必須チェックのみ待機（--required）
- fix: release.sh が dev-latest タグを拾う問題を修正
- ci: リリース戦略改善 — 冪等スクリプト・PRリリースノート・Pi自動ロールバック
- refactor: コード品質改善 — ArcAnimator抽出・obdState構造体化・errcheck導入
- docs: ドキュメント全面整備 — 実態との乖離修正 + 構造分割
- docs: キオスク終了を「画面3秒長押し」に修正
- ci: mainブランチ保護 + PRベースリリースフロー
- docs: Wi-Fiトラブルシューティングガイド追加
- ci: CI成功時のみdevデプロイを実行
- feat: RPMインジケーター追加 + gofmtエラー修正
- feat: RPMインジケーター追加（SEND削除）
- feat: MAP・燃料レートアーク追加 + UI改善
- feat: インマニ圧(MAP)センサー対応 — 表示・燃費推定・エンブレ判定
- fix: configバリデーション・ヘルスチェック強化・テスト拡充・ログ改善
- chore: 不要コード削除 + ドキュメント更新
- refactor: EMA平滑化を全て除去し生値を使用（スパイク除去は維持）
- fix: 燃費表示の精度改善 — レート補正係数追加・EMA修正・速度0表示
- fix: シミュレーションモードがAPI復帰後も停止しない問題を修正
- perf: メーターUI応答性改善 — LERP速度・CSS遷移を高速化
- fix: トリップ状態保存を距離ベース(0.1km)に変更し電源断での距離ロスを低減
- fix: スロットルアークのスケーリング修正（ベタ踏みで最大到達）
- refactor: 車種依存の閾値をconfig化・排気量連動化
- fix: OBD全値にスパイク除去+EMA平滑化フィルター追加
- feat: タッチパネルからキオスク終了 + WiFi未接続時キオスク抑止
- feat: Claude Codeスキル追加 + 燃費EMAスムージング + ポーリング200ms復帰
- docs: 算出ロジック・閾値一覧を追加
- feat: Pi自動デプロイ（develop push → 2分以内に自動更新）
- ci: GASデプロイをdevelopブランチでも実行
- fix: エンブレ判定改善 + ECO>30で平均燃費表示 + TEMP閾値変更
- feat: develop/mainブランチ戦略を導入
- fix: golangci-lint v2移行（CI Go 1.25対応）

---
Auto-generated by `make release`