### PR TITLE
fix: メインループの GAS 送信 goroutine 化でフリーズ防止

### DIFF
--- a/cmd/pi-obd-meter/app.go
+++ b/cmd/pi-obd-meter/app.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashimoto/pi-obd-meter/internal/maintenance"
@@ -49,6 +50,9 @@ type App struct {
 	totalKmMu    sync.Mutex
 	totalKmAccum float64
 	odoApplied   bool
+
+	maintSending atomic.Bool
+	retrySending atomic.Bool
 
 	startedAt time.Time
 }
@@ -120,6 +124,32 @@ func (app *App) getRealtimeData() RealtimeData {
 	app.dataMu.RLock()
 	defer app.dataMu.RUnlock()
 	return app.latestData
+}
+
+// sendMaintenanceStatusAsync はメンテナンス送信をバックグラウンドで実行する。
+// 既に送信中の場合はスキップする（二重実行防止）。
+func (app *App) sendMaintenanceStatusAsync(ctx context.Context) {
+	if !app.maintSending.CompareAndSwap(false, true) {
+		slog.Debug("メンテナンス送信スキップ（前回送信中）")
+		return
+	}
+	go func() {
+		defer app.maintSending.Store(false)
+		app.sendMaintenanceStatus(ctx)
+	}()
+}
+
+// retryPendingAsync はリトライをバックグラウンドで実行する。
+// 既にリトライ中の場合はスキップする（二重実行防止）。
+func (app *App) retryPendingAsync(ctx context.Context) {
+	if !app.retrySending.CompareAndSwap(false, true) {
+		slog.Debug("リトライスキップ（前回リトライ中）")
+		return
+	}
+	go func() {
+		defer app.retrySending.Store(false)
+		app.client.RetryPending(ctx)
+	}()
 }
 
 // sendMaintenanceStatus はメンテナンス状態をGASに送信し、レスポンスを処理する。

--- a/cmd/pi-obd-meter/main.go
+++ b/cmd/pi-obd-meter/main.go
@@ -243,10 +243,10 @@ func main() {
 			}
 
 		case <-retryTicker.C:
-			app.client.RetryPending(ctx)
+			app.retryPendingAsync(ctx)
 
 		case <-maintTicker.C:
-			app.sendMaintenanceStatus(ctx)
+			app.sendMaintenanceStatusAsync(ctx)
 
 		case sig := <-sigCh:
 			slog.Info("シグナル受信、シャットダウン開始", "signal", sig)


### PR DESCRIPTION
## Summary
- `sendMaintenanceStatus` / `RetryPending` が GAS の HTTP 応答待ちでメインループの `select` をブロックし、CAN データ処理が 1-2秒 止まっていた
- goroutine 化してメインループを止めないようにする
- `atomic.Bool` で二重実行を防止

## 変更内容
| ファイル | 内容 |
|---|---|
| `app.go` | `sendMaintenanceStatusAsync` / `retryPendingAsync` 追加（+30行） |
| `main.go` | ticker case で async 版を呼ぶように変更（2行） |

## 原因分析
```
case <-maintTicker.C:
    app.sendMaintenanceStatus(ctx)  // ← GAS に HTTP POST → 応答 1-2秒待ち
                                     //    この間 obdCh の CAN データが処理されない
                                     //    → ゲージがフリーズ
```

## Test plan
- [x] `go test -race` PASS
- [x] `golangci-lint` 0 issues
- [ ] Pi 実機: 走行中のフリーズが解消されたか確認

Closes #57 の残課題（WS 化後も残っていたフリーズ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)