### PR TITLE
Release v1.0.8

### DIFF
--- a/cmd/pi-obd-meter/config.go
+++ b/cmd/pi-obd-meter/config.go
@@ -179,11 +179,11 @@ func validateConfig(cfg *Config) {
 		slog.Warn("max_ps_rpm が不正、デフォルト使用", "value", cfg.MaxPSRPM)
 		cfg.MaxPSRPM = 6000
 	}
-	if cfg.ThrottleIdlePct < 0 || cfg.ThrottleIdlePct > 100 {
+	if cfg.ThrottleIdlePct < 0 || cfg.ThrottleIdlePct > 255 {
 		slog.Warn("throttle_idle_pct が不正、デフォルト使用", "value", cfg.ThrottleIdlePct)
 		cfg.ThrottleIdlePct = 11.5
 	}
-	if cfg.ThrottleMaxPct <= cfg.ThrottleIdlePct || cfg.ThrottleMaxPct > 100 {
+	if cfg.ThrottleMaxPct <= cfg.ThrottleIdlePct || cfg.ThrottleMaxPct > 255 {
 		slog.Warn("throttle_max_pct が不正、デフォルト使用", "value", cfg.ThrottleMaxPct)
 		cfg.ThrottleMaxPct = 78
 	}


### PR DESCRIPTION
## Release v1.0.8

### Changes since v0.3.1

- fix: throttle バリデーション上限を 255 に修正（CAN LOAD 生値対応）
- fix: メインループの GAS 送信を goroutine 化してフリーズ防止 (#99)
- docs: v1.0.6 に合わせてドキュメント全面更新
- fix: THROTTLE idle=1 + dimZone=5（アイドル時のピョコ防止）
- fix: THROTTLE dimZone を 10 に拡大
- fix: THROTTLE dimZone + ECO 色を VACUUM 同期
- fix: VACUUM ラベルの赤色も #f44336 に統一
- feat: バキューム計化 + VACUUM ラベル + 赤色統一
- fix: エンブレ判定 MAP 閾値を 35→30 kPa に変更
- feat: WebSocket リアルタイム配信 (#57)
- fix: メーター微調整 — 目盛り・数値位置・スロットル径
- fix: MAP アーク幅を 10px に統一（スロットル/RPM と揃える）
- fix: スロットル max を CAN LOAD 実測値 197 に合わせる
- fix: HOLD/LOCK 24px化 + ギア/レンジ グロー復活
- feat: 右パネル刷新 — MAP メーター + 4行インジケーター化
- tool: 実走テスト用スクリーンショット定期キャプチャスクリプト
- perf: HTTP ポーリング間隔を 50ms に戻す（CAN 直結対応）
- feat: GAS ダッシュボードを OIL 専用化 + docs 更新
- feat: 右パネル2連メーター化 + OIL専用メンテ + ECOグラデーション + 各種config化
- fix: TCC ロック判定を 0x231 B1 bit4 に修正
- revert: 3連メーター統合直後の状態に戻す
- revert: 3連メーター統合を全て元に戻す
- perf: ポーリング間隔 50ms→200ms + グロー復元
- perf: 全 drop-shadow 無効化 + 無変更時のRAF起動スキップ
- perf: 3連メーターの drop-shadow 全削除 — Pi GPU負荷軽減
- fix: トースト削除 + 3連メーターLERP高速化 (0.35→0.7)
- feat: 3連メーター + 警告灯を本番 meter.html に統合
- fix: CI lint エラー修正 — errcheck + gofmt
- docs: 実走テスト計画 — ギア比オーバーフロー検証 + TC ロック条件
- docs: CAN ギア比解析ドキュメント — 0x230 B2 オーバーフロー問題と解決
- docs: CLAUDE.md 更新 — 右パネル3連メーター・警告灯・CAN B2オーバーフロー
- fix: 0x230 B2 ギア比の1バイトオーバーフロー対応 (#80)
- feat: ギア比メーター色モード + P色変更 + CHECK警告灯
- feat: CHECK警告灯追加 + ギア比メーターの色設計確定
- feat: 3連メーター確定 — GEAR/MAP+AF/PS+TQ + フォント調整
- feat: 警告灯の並び順確定 + メンテ項目追加 + AC→AC.F
- feat: 警告灯システム — severity/alertLevel + メンテ項目拡充
- feat: 右パネル 3連二重アークメーター プロトタイプ + config追加
- feat: TRIP/ECO 色分け + タンク容量修正
- feat: メーター UI 調整 — 下部インジケーター + アイコン + 色分け
- feat: ギア/レンジインジケーターをメーター左上右上に配置
- feat: CAN パッシブ AT 制御データ + 全 OBD PID 追加
- fix: CAN未接続時もUIに切断状態を通知（ACC時フリーズ修正）
- feat: CAN直結モード (SocketCAN) + リーダー自動復帰 + MAP/LOAD実走ドキュメント
- feat: TRIP閾値をconfig.jsonで直接設定可能に
- fix: キオスク起動前にWiFi接続を待機（ループ）
- fix: キオスク終了後10秒で自動復帰 (Restart=always)
- fix: WiFiガードを削除してキオスク常時起動に変更
- feat: ECOランプ改善 — エンブレ=緑、>=6黄、<6赤 + オレンジを黄色に変更
- fix: 給油後トリップリセット不具合修正 + ELM327 panic修正
- feat: ECO閾値をconfig化 + TEMP閾値調整
- fix: ineffassign lint error blocking CI deploy
- fix: CAN キャプチャ保存先を /opt に変更
- fix: CAN キャプチャスクリプトの初期化とフィルタ修正
- feat: CAN キャプチャスクリプト + テスト手順書
- refactor: 冗長なfuelRateLH<0.01エンブレ判定を削除
- docs: ECO閾値ドキュメントを現行ロジックに更新
- fix: ECO橙/赤閾値を緩和 (10→6.2 km/L) + JS fallback統一
- fix: GASトリップ補正UX改善 + メーターフリーズ防止
- fix: ECO閾値調整 — green≥15/orange≥5/red<5 + エンブレ緑に戻す
- fix: Pi→GAS トリップ同期 — trip_km をペイロードに追加
- fix: GASからトリップ距離復元 + ドキュメント更新
- feat: ECO表示改善 — ReadFast即時判定・エンブレ消灯・UI簡素化
- feat: ELM327接続改善 — タイムアウト追加・ReadFast 2PID化・200msポーリング
- docs: メーター表示指標ガイドを追加
- ui: トリップ補正をメンテの上に移動 + ボタン色入れ替え
- feat: トリップ補正機能（リセット→補正に変更） #51
- test: カバレッジ強化（app.go, sender, trip）
- fix: obd_loop_test.go のlintエラー修正（未使用モック削除・ineffassign解消）
- refactor: OBD読み取りをgoroutine+channelに分離 (#37)
- ci: Claude Code Review ワークフロー削除
- feat: Claude Code Review を実用的なゲートに改善
- fix: Claude Code Review に actions/checkout ステップ追加
- fix: release.sh の自動バージョン計算を全タグ対象に修正
- fix: reader_test.go の gofmt フォーマット修正
- fix: Claude Code Review に id-token: write パーミッション追加
- feat: ダッシュボードに走行統計カード + トリップリセット機能追加
- test: obd Readerテスト追加 + GAS給油ログの未使用カラム削除
- fix: release.sh で必須チェックのみ待機（--required）
- fix: release.sh が dev-latest タグを拾う問題を修正
- ci: リリース戦略改善 — 冪等スクリプト・PRリリースノート・Pi自動ロールバック
- refactor: コード品質改善 — ArcAnimator抽出・obdState構造体化・errcheck導入
- docs: ドキュメント全面整備 — 実態との乖離修正 + 構造分割
- docs: キオスク終了を「画面3秒長押し」に修正
- ci: mainブランチ保護 + PRベースリリースフロー
- docs: Wi-Fiトラブルシューティングガイド追加
- ci: CI成功時のみdevデプロイを実行
- feat: RPMインジケーター追加 + gofmtエラー修正
- feat: RPMインジケーター追加（SEND削除）
- feat: MAP・燃料レートアーク追加 + UI改善
- feat: インマニ圧(MAP)センサー対応 — 表示・燃費推定・エンブレ判定
- fix: configバリデーション・ヘルスチェック強化・テスト拡充・ログ改善
- chore: 不要コード削除 + ドキュメント更新
- refactor: EMA平滑化を全て除去し生値を使用（スパイク除去は維持）
- fix: 燃費表示の精度改善 — レート補正係数追加・EMA修正・速度0表示
- fix: シミュレーションモードがAPI復帰後も停止しない問題を修正
- perf: メーターUI応答性改善 — LERP速度・CSS遷移を高速化
- fix: トリップ状態保存を距離ベース(0.1km)に変更し電源断での距離ロスを低減
- fix: スロットルアークのスケーリング修正（ベタ踏みで最大到達）
- refactor: 車種依存の閾値をconfig化・排気量連動化
- fix: OBD全値にスパイク除去+EMA平滑化フィルター追加
- feat: タッチパネルからキオスク終了 + WiFi未接続時キオスク抑止
- feat: Claude Codeスキル追加 + 燃費EMAスムージング + ポーリング200ms復帰
- docs: 算出ロジック・閾値一覧を追加
- feat: Pi自動デプロイ（develop push → 2分以内に自動更新）
- ci: GASデプロイをdevelopブランチでも実行
- fix: エンブレ判定改善 + ECO>30で平均燃費表示 + TEMP閾値変更
- feat: develop/mainブランチ戦略を導入
- fix: golangci-lint v2移行（CI Go 1.25対応）

---
Auto-generated by `make release`