### PR TITLE
Release v1.2.0

### DIFF
--- a/web/static/js/gauge.js
+++ b/web/static/js/gauge.js
@@ -256,7 +256,7 @@ export function updateGear(gear, range, hold, tcLocked) {
 
 // --- RPM色: 回転数に応じた色 ---
 // RPM→色（ZJ-VE 91PS/6000rpm, 124Nm/3500rpm に合わせた8段階）
-function rpmColor(rpm) {
+export function rpmColor(rpm) {
   if (rpm >= 5000) return '#f44336';  // 赤
   if (rpm >= 4000) return '#ff9800';  // 橙
   if (rpm >= 3500) return '#fdd835';  // 黄
@@ -268,12 +268,7 @@ function rpmColor(rpm) {
 }
 
 // --- RPM アニメーター ---
-let rpmAnimator;
 const RPM_MAX = 8000;
-
-export function updateRPM(rpm) {
-  if (rpmAnimator) rpmAnimator.update(rpm);
-}
 
 // --- スロットル アニメーター ---
 let thrAnimator;
@@ -365,29 +360,30 @@ export function buildSpeedGauge(svgId, cfg) {
   svgEl(svg, 'path', { d: arcPath(cx, cy, 200, ARC_START, ARC_END), fill: 'none', stroke: '#1a1a24', 'stroke-width': 1 });
   svgEl(svg, 'path', { d: arcPath(cx, cy, 175, ARC_START, ARC_END), fill: 'none', stroke: '#1a1a24', 'stroke-width': 1 });
 
-  // RPM トラック（radialGradient ストローク）
-  const rpmR = r + RPM_R_OFFSET;
-  createGradientTrack(svg, cx, cy, rpmR, 12, ARC_START, ARC_END, '#040408', '#3a3a48', '#040408');
+  // === 外側: 速度 (km/h) アーク ===
+  const outerR = r + RPM_R_OFFSET;
+  createGradientTrack(svg, cx, cy, outerR, 12, ARC_START, ARC_END, '#040408', '#3a3a48', '#040408');
+  const spdArcEl = createBloom(svg, 'path', { d: '', fill: 'none', stroke: '#555', 'stroke-width': 10, 'stroke-linecap': 'round' }, 8, 0.35);
+
+  // === 中央: RPM トラック + レッドゾーン ===
+  createGradientTrack(svg, cx, cy, r, 16, ARC_START, ARC_END, '#040408', '#34344a', '#040408');
   // Redzone background (6500-8000)
   const redStart = ARC_START + (6500 / RPM_MAX) * ARC_SWEEP;
-  createGradientTrack(svg, cx, cy, rpmR, 12, redStart, ARC_END, '#200000', '#7a0000', '#200000');
-  const rpmArcEl = createBloom(svg, 'path', { d: '', fill: 'none', stroke: '#555', 'stroke-width': 10, 'stroke-linecap': 'round' }, 8, 0.35);
+  createGradientTrack(svg, cx, cy, r, 16, redStart, ARC_END, '#200000', '#7a0000', '#200000');
 
-  // 速度トラック（radialGradient ストローク）
-  createGradientTrack(svg, cx, cy, r, 16, ARC_START, ARC_END, '#040408', '#34344a', '#040408');
-
-  // Ticks
-  const total = mj * mn;
-  for (let i = 0; i <= total; i++) {
-    const a = ARC_START + (i / total) * ARC_SWEEP;
-    const isMj = i % mn === 0;
+  // RPM 目盛り (0〜8, ×1000)
+  const rpmMj = 8, rpmMn = 5;
+  const rpmTotal = rpmMj * rpmMn;
+  for (let i = 0; i <= rpmTotal; i++) {
+    const a = ARC_START + (i / rpmTotal) * ARC_SWEEP;
+    const isMj = i % rpmMn === 0;
     const ri = isMj ? r - 30 : r - 18;
     const ro = r + 4;
     const [x1, y1] = polarToXY(cx, cy, ri, a);
     const [x2, y2] = polarToXY(cx, cy, ro, a);
     svgEl(svg, 'line', { x1, y1, x2, y2, stroke: isMj ? '#aaa' : '#444', 'stroke-width': isMj ? 5 : 2.5 });
     if (isMj) {
-      const v = min + (i / total) * (max - min);
+      const v = (i / rpmTotal) * (RPM_MAX / 1000); // 0〜8
       const [lx, ly] = polarToXY(cx, cy, r - 54, a);
       const t = svgEl(svg, 'text', { x: lx, y: ly, class: 'tk-lbl', fill: '#fff', 'font-size': tkSz });
       t.textContent = Math.round(v);
@@ -433,15 +429,13 @@ export function buildSpeedGauge(svgId, cfg) {
   bloomText(holdLabelEl, 2.5, 0.4);
   bloomText(lockLabelEl, 2.5, 0.4);
 
-  // Value arc
-  const va = createBloom(svg, 'path', { d: '', fill: 'none', stroke: cfg.color, 'stroke-width': 12, 'stroke-linecap': 'round' }, 10, 0.38);
-  applyGlow(va, cfg.color);
+  // RPM Value arc (中央、針と連動)
+  const rpmArc = createBloom(svg, 'path', { d: '', fill: 'none', stroke: cfg.color, 'stroke-width': 12, 'stroke-linecap': 'round' }, 10, 0.38);
 
-  // Needle
+  // RPM Needle (中央)
   const [nx0, ny0] = polarToXY(cx, cy, r - 24, ARC_START);
   const [tx0, ty0] = polarToXY(cx, cy, -16, ARC_START);
   const nd = createBloom(svg, 'line', { x1: tx0, y1: ty0, x2: nx0, y2: ny0, stroke: cfg.color, 'stroke-width': 6, 'stroke-linecap': 'round', 'transform-origin': `${cx}px ${cy}px` }, 10, 0.3);
-  applyGlow(nd, cfg.color);
 
   // Center dot
   svgEl(svg, 'circle', { cx, cy, r: 8, fill: '#1a1a22', stroke: '#444', 'stroke-width': 2 });
@@ -470,60 +464,69 @@ export function buildSpeedGauge(svgId, cfg) {
   thrLabel.textContent = 'THROTTLE';
   bloomText(thrLabel, 2.5, 0.4);
 
-  // ArcAnimator インスタンス生成
+  // === ArcAnimator ===
+  // スロットル (内側)
   thrAnimator = new ArcAnimator({
     cx, cy, r: throttleR, maxVal: 100, lerpSpeed: 0.4,
     arcEl: thrArcEl, offColor: '#333', activeThreshold: 0.5, labelEl: thrLabel, dimZone: 5,
   });
 
-  // RPM ArcAnimator（目盛り数字の上を通過、色はRPMに応じて動的変化）
-  rpmAnimator = new ArcAnimator({
-    cx, cy, r: rpmR, maxVal: RPM_MAX, lerpSpeed: 0.4,
-    arcEl: rpmArcEl, offColor: '#222', activeThreshold: 100,
+  // 速度 外側アーク ArcAnimator (速度色で描画、目盛りなし)
+  const spdAnimator = new ArcAnimator({
+    cx, cy, r: outerR, maxVal: max, lerpSpeed: 0.4,
+    arcEl: spdArcEl, offColor: '#222', activeThreshold: 1,
   });
-  rpmAnimator._lerp = function() {
-    const delta = rpmAnimator.tgt - rpmAnimator.cur;
-    rpmAnimator.cur = Math.abs(delta) > LERP_THRESHOLD ? rpmAnimator.cur + delta * rpmAnimator.lerpSpeed : rpmAnimator.tgt;
-    const pct = Math.max(0, Math.min(100, rpmAnimator.cur / rpmAnimator.maxVal * 100));
+  spdAnimator._lerp = function() {
+    const delta = spdAnimator.tgt - spdAnimator.cur;
+    spdAnimator.cur = Math.abs(delta) > LERP_THRESHOLD ? spdAnimator.cur + delta * spdAnimator.lerpSpeed : spdAnimator.tgt;
+    const pct = Math.max(0, Math.min(100, spdAnimator.cur / spdAnimator.maxVal * 100));
     const angle = ARC_START + (pct / 100) * ARC_SWEEP;
-    rpmArcEl.setAttribute('d', pct > 0.5 ? arcPath(cx, cy, rpmR, ARC_START, angle) : '');
-    const active = rpmAnimator.cur > rpmAnimator.activeThreshold;
-    const col = active ? rpmColor(rpmAnimator.cur) : rpmAnimator.offColor;
-    rpmArcEl.setAttribute('stroke', col);
-    applyGlow(rpmArcEl, col);
-    rpmValEl.textContent = active ? Math.round(rpmAnimator.cur).toLocaleString() : '--';
-    rpmValEl.setAttribute('fill', col);
-    rpmUnitEl.setAttribute('fill', '#fff');
-    rpmAnimator.rafId = Math.abs(rpmAnimator.cur - rpmAnimator.tgt) > LERP_STOP ? requestAnimationFrame(rpmAnimator._lerp) : 0;
+    spdArcEl.setAttribute('d', pct > 0.5 ? arcPath(cx, cy, outerR, ARC_START, angle) : '');
+    const active = spdAnimator.cur > spdAnimator.activeThreshold;
+    const col = active ? speedColor(spdAnimator.cur) : spdAnimator.offColor;
+    spdArcEl.setAttribute('stroke', col);
+    // 速度の数値も更新 (大きい数字)
+    nm.textContent = cfg.fmt(spdAnimator.cur);
+    nm.setAttribute('fill', col);
+    spdAnimator.rafId = Math.abs(spdAnimator.cur - spdAnimator.tgt) > LERP_STOP ? requestAnimationFrame(spdAnimator._lerp) : 0;
   };
 
-  // Speed Lerp animation
-  let curVal = min, tgtVal = min, rafId = 0;
-  function lerp() {
-    const delta = tgtVal - curVal;
-    curVal = Math.abs(delta) > LERP_THRESHOLD ? curVal + delta * LERP_SPEED : tgtVal;
-    const clamped = Math.max(min, Math.min(max, curVal));
-    const angle = ARC_START + ((clamped - min) / (max - min)) * ARC_SWEEP;
-    va.setAttribute('d', clamped > min + 0.001 ? arcPath(cx, cy, r, ARC_START, angle) : '');
-    nm.textContent = cfg.fmt(curVal);
-    rafId = Math.abs(curVal - tgtVal) > LERP_STOP ? requestAnimationFrame(lerp) : 0;
+  // RPM 中央アーク + 針 LERP (RPM色で描画)
+  let rpmCur = 0, rpmTgt = 0, rpmRafId = 0;
+  function rpmLerp() {
+    const delta = rpmTgt - rpmCur;
+    rpmCur = Math.abs(delta) > LERP_THRESHOLD ? rpmCur + delta * LERP_SPEED : rpmTgt;
+    const pct = Math.max(0, Math.min(100, rpmCur / RPM_MAX * 100));
+    const angle = ARC_START + (pct / 100) * ARC_SWEEP;
+    rpmArc.setAttribute('d', pct > 0.5 ? arcPath(cx, cy, r, ARC_START, angle) : '');
+    const active = rpmCur > 100;
+    const col = active ? rpmColor(rpmCur) : '#222';
+    rpmArc.setAttribute('stroke', col);
+    nd.setAttribute('stroke', col);
+    rotateWithBloom(nd, `rotate(${angle - ARC_START}deg)`);
+    // RPM 数字
+    rpmValEl.textContent = active ? Math.round(rpmCur).toLocaleString() : '--';
+    rpmValEl.setAttribute('fill', col);
+    rpmUnitEl.setAttribute('fill', '#fff');
+    rpmRafId = Math.abs(rpmCur - rpmTgt) > LERP_STOP ? requestAnimationFrame(rpmLerp) : 0;
   }
 
-  // 直接アニメーション（LERP なし、起動アニメ用）
-  // 起動アニメ中は glow 無し (Pi 4 WPE で feGaussianBlur x 4 が重い)
+  // 起動アニメ用 直接アニメーション (LERP なし)
   function setDirect(pct, col) {
+    // RPM 中央アーク + 針 (主役)
     const angle = ARC_START + pct * ARC_SWEEP;
-    va.setAttribute('d', pct > 0.001 ? arcPath(cx, cy, r, ARC_START, angle) : '');
+    rpmArc.setAttribute('d', pct > 0.001 ? arcPath(cx, cy, r, ARC_START, angle) : '');
     nd.style.transition = 'none';
     if (nd._bloom) nd._bloom.style.transition = 'none';
     rotateWithBloom(nd, `rotate(${angle - ARC_START}deg)`);
-    if (col) { nd.setAttribute('stroke', col); va.setAttribute('stroke', col); }
+    if (col) { nd.setAttribute('stroke', col); rpmArc.setAttribute('stroke', col); }
   }
 
-  function setRPMDirect(pct, col) {
+  function setSpeedDirect(pct, col) {
+    // 速度 外側アーク
     const angle = ARC_START + pct * ARC_SWEEP;
-    rpmArcEl.setAttribute('d', pct > 0.001 ? arcPath(cx, cy, rpmR, ARC_START, angle) : '');
-    if (col) rpmArcEl.setAttribute('stroke', col);
+    spdArcEl.setAttribute('d', pct > 0.001 ? arcPath(cx, cy, outerR, ARC_START, angle) : '');
+    if (col) spdArcEl.setAttribute('stroke', col);
   }
 
   function setThrDirect(pct, col) {
@@ -533,20 +536,22 @@ export function buildSpeedGauge(svgId, cfg) {
   }
 
   function restoreTransition() {
-    nd.style.transition = 'transform 0.05s ease-out';  // 針は即応答
+    nd.style.transition = 'transform 0.05s ease-out';
     if (nd._bloom) nd._bloom.style.transition = 'transform 0.8s cubic-bezier(0.18, 0.89, 0.32, 1.15)';
   }
 
   return {
-    update(value, col) {
-      tgtVal = value;
-      const clamped = Math.max(min, Math.min(max, value));
-      const angle = ARC_START + ((clamped - min) / (max - min)) * ARC_SWEEP;
-      rotateWithBloom(nd, `rotate(${angle - ARC_START}deg)`);
-      if (col) { nd.setAttribute('stroke', col); va.setAttribute('stroke', col); nm.setAttribute('fill', col); }
-      if (!rafId) rafId = requestAnimationFrame(lerp);
+    // speed: 速度 → 外側アーク + 大数値
+    // rpm: RPM → 中央アーク + 針 + RPM 数字
+    update(speed, rpm, spdCol, rpmCol) {
+      // 速度 (外側アーク + 大数値)
+      spdAnimator.update(speed);
+      // RPM (中央アーク + 針)
+      rpmTgt = rpm;
+      if (rpmCol) { nd.setAttribute('stroke', rpmCol); rpmArc.setAttribute('stroke', rpmCol); }
+      if (!rpmRafId) rpmRafId = requestAnimationFrame(rpmLerp);
     },
-    setDirect, setRPMDirect, setThrDirect, restoreTransition,
+    setDirect, setSpeedDirect, setThrDirect, restoreTransition,
     getElements() { return { nm, rpmValEl, rpmUnitEl, thrLabel }; }
   };
 }

--- a/web/static/js/indicators.js
+++ b/web/static/js/indicators.js
@@ -330,7 +330,7 @@ export function createIndicators(panelEl) {
     if (isMj) {
       const v = VAC_MIN + (i / VAC_TOTAL) * (VAC_MAX - VAC_MIN);
       const [lx, ly] = polar(MAP_CX, MAP_CY, MAP_R - 32, a);
-      const t = svgEl(svg, 'text', { x: lx, y: ly, class: 'tk-lbl', fill: '#fff', 'font-size': 22 });
+      const t = svgEl(svg, 'text', { x: lx, y: ly, class: 'tk-lbl', fill: '#fff', 'font-size': 18 });
       t.textContent = v === 0 ? '0' : v.toFixed(1).replace('-0.', '-.');
     }
   }

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -2,7 +2,7 @@
 // Main — エントリポイント + WebSocket / HTTP ポーリング
 // ============================================================
 
-import { buildSpeedGauge, updateThrottle, updateRPM, updateGear, speedColor, setThrottleIdleBaseline, setThrottleMaxPct } from './gauge.js';
+import { buildSpeedGauge, updateThrottle, updateGear, speedColor, rpmColor, setThrottleIdleBaseline, setThrottleMaxPct } from './gauge.js';
 import { createIndicators, updateIndicators, setCoolantThresholds, setEcoGradientMax, setMapDirect, restoreMapTransition } from './indicators.js';
 
 const DEFAULTS = {
@@ -37,9 +37,9 @@ function applyData(d) {
   const obdOn = d.obd_connected !== false;
   document.body.classList.toggle('obd-offline', !obdOn);
   const spd = obdOn ? (d.speed_kmh || 0) : 0;
-  gs.update(spd, speedColor(spd));
+  const rpm = obdOn ? (d.rpm || 0) : 0;
+  gs.update(spd, rpm, speedColor(spd), rpmColor(rpm));
   updateThrottle(obdOn ? (d.throttle_pos || 0) : 0);
-  updateRPM(obdOn ? (d.rpm || 0) : 0);
   updateGear(obdOn ? (d.gear || 0) : 0, obdOn ? (d.at_range_str || '-') : '-', obdOn && (d.hold || false), obdOn && (d.tc_locked || false));
   updateIndicators(dom, d, conf);
 }
@@ -210,7 +210,7 @@ function bootAnimation(gauge) {
         // Phase 1: 針 0 → MAX
         const t = easeInOut(elapsed / SWEEP_OUT);
         gauge.setDirect(t, spdCol);
-        gauge.setRPMDirect(t, rpmCol);
+        gauge.setSpeedDirect(t, rpmCol);
         gauge.setThrDirect(t, thrCol);
         setMapDirect(t, mapCol);
         requestAnimationFrame(frame);
@@ -218,14 +218,14 @@ function bootAnimation(gauge) {
         // Phase 2: 針 MAX → 0
         const t = easeInOut((elapsed - SWEEP_OUT) / SWEEP_BACK);
         gauge.setDirect(1 - t, spdCol);
-        gauge.setRPMDirect(1 - t, rpmCol);
+        gauge.setSpeedDirect(1 - t, rpmCol);
         gauge.setThrDirect(1 - t, thrCol);
         setMapDirect(1 - t, mapCol);
         requestAnimationFrame(frame);
       } else if (elapsed < SWEEP_OUT + SWEEP_BACK + FADE_IN) {
         // Phase 3: 針は 0、テキスト/ラベルが CSS transition でフェードイン
         gauge.setDirect(0, '#78909c');
-        gauge.setRPMDirect(0, '#222');
+        gauge.setSpeedDirect(0, '#222');
         gauge.setThrDirect(0, '#333');
         setMapDirect(0, '#333');
         // 一度だけ class 除去 (CSS で 800ms フェード開始)


### PR DESCRIPTION
## Release v1.2.0

### Changes since v0.3.1

- feat: タコメーター中心レイアウトに変更
- fix: gofmt 適用
- docs: v1.1.0 リリース前ドキュメント更新
- feat: 大数値3箇所にオフセット影 + demo データ範囲拡大
- feat: 枠要素に bloom 追加 + インナーリング明度調整
- feat: アーク bloom 幅広化 + clone 方式統一
- feat: 針の残像 bloom + ACC 全体消灯 + demo モード競合解消
- feat: クライアントエラー/フリーズ検知ログ + オープニング Phase 3 + OBD 未接続プレースホルダー
- Revert "Merge pull request #108 from RyoheiHashimoto/feature/sdl-revival"
- chore: go mod tidy for SDL deps
- feat(sdl): SDL 版復活 第1段階 - main.go / CI / deps
- chore: SDL 版復活用ブランチ作成
- fix: SSH ロックアウト復旧コードを起動時に実行
- feat: fake bloom で全要素を発光化 + 多層ベゼル
- feat: SVGフィルタでグロー強化 + メタリックベゼル + ガラス反射
- feat: Wayland/WPE キオスク移行 + 白フラッシュ解消
- fix: バキューム中心グラデ明るく + ガラスパネル色調整
- feat: ブラウザ版デザイン大幅改善
- feat: SDL2 直描画を廃止、ブラウザ版に一本化
- feat: ブラウザ版にSDL版のデザイン改善を移植
- perf: アーク polyline ステップ数を 1/3 に削減 (1.5→0.5 per degree)
- debug: アーク・針の描画時間計測を追加（60フレームごとにログ出力）
- revert: グロー4層・毎フレーム描画・60fps vsync に戻す
- chore: 未使用の dirty tracking フィールド削除
- perf: グロー4層→1層に軽量化 + 60fps vsync 復帰
- perf: アーク・針の角度ベース dirty tracking で CPU ラスタライズ削減
- perf: 30fps フレームレート制限 + vsync 除去
- fix: LERP を delta time ベースに変更（フレームレート非依存）
- fix: lint エラー修正 (gofmt, staticcheck, unused)
- fix: gofmt + errcheck lint エラー修正
- chore: go mod tidy
- chore: 未使用の定数・色変数を削除
- feat: 右下インジケーターにガラスパネル + バキューム中心グラデ明るく
- feat: 速度/RPM/バキューム数値にドロップシャドウ + 同心円ガイドライン
- feat: 速度・RPM 色閾値を ZJ-VE / DYデミオの実用域に最適化
- fix: バキューム計の目盛りをインナーリングの上に描画
- feat: SDL版メーター用 systemd サービス + セットアップスクリプト + CI 更新
- feat: ラジアルグラデーション背景・立体トラック・起動プレースホルダー
- feat: sdlui を canvas ベースに全面書き換え + 起動アニメーション
- feat: tdewolff/canvas プロトタイプ (速度計/バキューム計/インジケーター)
- fix: OIL表示を残りkmから交換後走行kmに変更
- fix: SDLモードでOBDデータ処理ループが動作しないバグを修正
- fix: 右パネル位置をブラウザ版に合わせる + 目盛りラベル修正
- fix: グロー大幅強化 + 丸キャップ + RPMカンマ区切り + ギア枠色つき
- fix: フォントキャッシュ LRU 化 + グロー軽減 + 静的テクスチャ左パネル限定
- fix: throttle バリデーション上限を 255 に修正（CAN LOAD 生値対応）
- fix: メインループの GAS 送信を goroutine 化してフリーズ防止 (#99)
- feat: SDL2 Phase 2 — 全ゲージ + 右パネル + 3秒長押し終了 (#97)
- feat: SDL2 Phase 1 — 基盤 + 速度ゲージ + デモモード (#96)
- docs: v1.0.6 に合わせてドキュメント全面更新
- fix: THROTTLE idle=1 + dimZone=5（アイドル時のピョコ防止）
- fix: THROTTLE dimZone を 10 に拡大
- fix: THROTTLE dimZone + ECO 色を VACUUM 同期
- fix: VACUUM ラベルの赤色も #f44336 に統一
- feat: バキューム計化 + VACUUM ラベル + 赤色統一
- fix: エンブレ判定 MAP 閾値を 35→30 kPa に変更
- feat: WebSocket リアルタイム配信 (#57)
- fix: メーター微調整 — 目盛り・数値位置・スロットル径
- fix: MAP アーク幅を 10px に統一（スロットル/RPM と揃える）
- fix: スロットル max を CAN LOAD 実測値 197 に合わせる
- fix: HOLD/LOCK 24px化 + ギア/レンジ グロー復活
- feat: 右パネル刷新 — MAP メーター + 4行インジケーター化
- tool: 実走テスト用スクリーンショット定期キャプチャスクリプト
- perf: HTTP ポーリング間隔を 50ms に戻す（CAN 直結対応）
- feat: GAS ダッシュボードを OIL 専用化 + docs 更新
- feat: 右パネル2連メーター化 + OIL専用メンテ + ECOグラデーション + 各種config化
- fix: TCC ロック判定を 0x231 B1 bit4 に修正
- revert: 3連メーター統合直後の状態に戻す
- revert: 3連メーター統合を全て元に戻す
- perf: ポーリング間隔 50ms→200ms + グロー復元
- perf: 全 drop-shadow 無効化 + 無変更時のRAF起動スキップ
- perf: 3連メーターの drop-shadow 全削除 — Pi GPU負荷軽減
- fix: トースト削除 + 3連メーターLERP高速化 (0.35→0.7)
- feat: 3連メーター + 警告灯を本番 meter.html に統合
- fix: CI lint エラー修正 — errcheck + gofmt
- docs: 実走テスト計画 — ギア比オーバーフロー検証 + TC ロック条件
- docs: CAN ギア比解析ドキュメント — 0x230 B2 オーバーフロー問題と解決
- docs: CLAUDE.md 更新 — 右パネル3連メーター・警告灯・CAN B2オーバーフロー
- fix: 0x230 B2 ギア比の1バイトオーバーフロー対応 (#80)
- feat: ギア比メーター色モード + P色変更 + CHECK警告灯
- feat: CHECK警告灯追加 + ギア比メーターの色設計確定
- feat: 3連メーター確定 — GEAR/MAP+AF/PS+TQ + フォント調整
- feat: 警告灯の並び順確定 + メンテ項目追加 + AC→AC.F
- feat: 警告灯システム — severity/alertLevel + メンテ項目拡充
- feat: 右パネル 3連二重アークメーター プロトタイプ + config追加
- feat: TRIP/ECO 色分け + タンク容量修正
- feat: メーター UI 調整 — 下部インジケーター + アイコン + 色分け
- feat: ギア/レンジインジケーターをメーター左上右上に配置
- feat: CAN パッシブ AT 制御データ + 全 OBD PID 追加
- fix: CAN未接続時もUIに切断状態を通知（ACC時フリーズ修正）
- feat: CAN直結モード (SocketCAN) + リーダー自動復帰 + MAP/LOAD実走ドキュメント
- feat: TRIP閾値をconfig.jsonで直接設定可能に
- fix: キオスク起動前にWiFi接続を待機（ループ）
- fix: キオスク終了後10秒で自動復帰 (Restart=always)
- fix: WiFiガードを削除してキオスク常時起動に変更
- feat: ECOランプ改善 — エンブレ=緑、>=6黄、<6赤 + オレンジを黄色に変更
- fix: 給油後トリップリセット不具合修正 + ELM327 panic修正
- feat: ECO閾値をconfig化 + TEMP閾値調整
- fix: ineffassign lint error blocking CI deploy
- fix: CAN キャプチャ保存先を /opt に変更
- fix: CAN キャプチャスクリプトの初期化とフィルタ修正
- feat: CAN キャプチャスクリプト + テスト手順書
- refactor: 冗長なfuelRateLH<0.01エンブレ判定を削除
- docs: ECO閾値ドキュメントを現行ロジックに更新
- fix: ECO橙/赤閾値を緩和 (10→6.2 km/L) + JS fallback統一
- fix: GASトリップ補正UX改善 + メーターフリーズ防止
- fix: ECO閾値調整 — green≥15/orange≥5/red<5 + エンブレ緑に戻す
- fix: Pi→GAS トリップ同期 — trip_km をペイロードに追加
- fix: GASからトリップ距離復元 + ドキュメント更新
- feat: ECO表示改善 — ReadFast即時判定・エンブレ消灯・UI簡素化
- feat: ELM327接続改善 — タイムアウト追加・ReadFast 2PID化・200msポーリング
- docs: メーター表示指標ガイドを追加
- ui: トリップ補正をメンテの上に移動 + ボタン色入れ替え
- feat: トリップ補正機能（リセット→補正に変更） #51
- test: カバレッジ強化（app.go, sender, trip）
- fix: obd_loop_test.go のlintエラー修正（未使用モック削除・ineffassign解消）
- refactor: OBD読み取りをgoroutine+channelに分離 (#37)
- ci: Claude Code Review ワークフロー削除
- feat: Claude Code Review を実用的なゲートに改善
- fix: Claude Code Review に actions/checkout ステップ追加
- fix: release.sh の自動バージョン計算を全タグ対象に修正
- fix: reader_test.go の gofmt フォーマット修正
- fix: Claude Code Review に id-token: write パーミッション追加
- feat: ダッシュボードに走行統計カード + トリップリセット機能追加
- test: obd Readerテスト追加 + GAS給油ログの未使用カラム削除
- fix: release.sh で必須チェックのみ待機（--required）
- fix: release.sh が dev-latest タグを拾う問題を修正
- ci: リリース戦略改善 — 冪等スクリプト・PRリリースノート・Pi自動ロールバック
- refactor: コード品質改善 — ArcAnimator抽出・obdState構造体化・errcheck導入
- docs: ドキュメント全面整備 — 実態との乖離修正 + 構造分割
- docs: キオスク終了を「画面3秒長押し」に修正
- ci: mainブランチ保護 + PRベースリリースフロー
- docs: Wi-Fiトラブルシューティングガイド追加
- ci: CI成功時のみdevデプロイを実行
- feat: RPMインジケーター追加 + gofmtエラー修正
- feat: RPMインジケーター追加（SEND削除）
- feat: MAP・燃料レートアーク追加 + UI改善
- feat: インマニ圧(MAP)センサー対応 — 表示・燃費推定・エンブレ判定
- fix: configバリデーション・ヘルスチェック強化・テスト拡充・ログ改善
- chore: 不要コード削除 + ドキュメント更新
- refactor: EMA平滑化を全て除去し生値を使用（スパイク除去は維持）
- fix: 燃費表示の精度改善 — レート補正係数追加・EMA修正・速度0表示
- fix: シミュレーションモードがAPI復帰後も停止しない問題を修正
- perf: メーターUI応答性改善 — LERP速度・CSS遷移を高速化
- fix: トリップ状態保存を距離ベース(0.1km)に変更し電源断での距離ロスを低減
- fix: スロットルアークのスケーリング修正（ベタ踏みで最大到達）
- refactor: 車種依存の閾値をconfig化・排気量連動化
- fix: OBD全値にスパイク除去+EMA平滑化フィルター追加
- feat: タッチパネルからキオスク終了 + WiFi未接続時キオスク抑止
- feat: Claude Codeスキル追加 + 燃費EMAスムージング + ポーリング200ms復帰
- docs: 算出ロジック・閾値一覧を追加
- feat: Pi自動デプロイ（develop push → 2分以内に自動更新）
- ci: GASデプロイをdevelopブランチでも実行
- fix: エンブレ判定改善 + ECO>30で平均燃費表示 + TEMP閾値変更
- feat: develop/mainブランチ戦略を導入
- fix: golangci-lint v2移行（CI Go 1.25対応）

---
Auto-generated by `make release`