### PR TITLE
Release v1.3.1

### DIFF
--- a/web/static/js/gauge.js
+++ b/web/static/js/gauge.js
@@ -269,8 +269,8 @@ export function rpmColor(rpm) {
   if (rpm >= 4000) return '#ff9800';  // 橙
   if (rpm >= 3500) return '#fdd835';  // 黄
   if (rpm >= 3000) return '#76ff03';  // 黄緑（パワーバンド突入）
-  if (rpm >= 2000) return '#69f0ae';  // 緑（通常走行）
-  if (rpm >= 1500) return '#26c6da';  // 水色（街中走行）
+  if (rpm >= 2500) return '#69f0ae';  // 緑（通常走行）
+  if (rpm >= 2000) return '#26c6da';  // 水色（街中走行）
   if (rpm >= 1000) return '#42a5f5';  // 青（アイドル付近）
   return '#78909c';                    // 非アクティブ
 }


### PR DESCRIPTION
## Release v1.3.1

### Changes since v0.3.1

- tune: RPM色域を変更 (青〜2000 / 水色2000-2500 / 緑2500-3000)
- fix: 切断時のバキューム針位置を左端 (-1.0 bar / 0 kPa) に修正
- feat: 通信断 (ACC OFF/Pi 落ち) で針を即座に 0 / 大気圧へ
- tune: RNG 警告閾値を TRIP と等価に (満タン 500km 想定で 150/100/50)
- tune: RPM 矢印を控えめサイズに、bloom 派手化は revert
- ui: RPM 矢印の bloom を派手に (針と同等以上のグロー)
- fix: gofmt 修正 (Config struct タグ整列、brightness 削除に伴う tag 幅縮小)
- remove: 動作してなかった輝度自動制御を削除 + RPM 矢印を三角に戻す
- fix: validateConfig の FuelRateCorrection フォールバック取り残しを 1.7 → 1.3 に
- ui: RPM 上昇/下降インジケーターを三角形 → LED ドット風の円に
- ui: RPM 矢印の Y を 6px 下げる微調整
- calib: 燃費補正係数を 1.7 → 1.3 に再校正 (実測 13.4 km/L 反映)
- tune: RPM 矢印のアイドル誤発火閾値を 50 → 150 rpm/s に
- feat: 冷感始動時の自動 candump 仕掛け (arm 方式)
- feat: RPM 表示の左右に上昇/下降矢印 (▼/▲) を追加
- chore: 未使用のエンジン稼働時間トラッカーを削除
- calib: fuel_rate_correction を 1.3 → 1.7 に校正
- fix: 給油後の TRIP/RNG 復活バグ (GAS の last_refuel_km 競合)
- ui: 右パネル 2 行目を RNG、3 行目を TRIP に並び替え
- ui: RNG 表示を整数 → 小数点 1 桁に
- refactor: RNG カラーを TRIP と同じ 4 段階刻みに統一
- feat: Row 1 を給油残距離 (RNG) に + TRIP との位置入れ替え
- feat: エンジン稼働時間をハイブリッド方式に + 秒表示「MMs」白固定
- feat: RUN 行に秒表示を追加 (単位位置)
- feat: エンジン稼働時間を Row 1 に追加 + 時計削除
- revert: 時計を fc7d903 の状態に (HH:MM:SS、font 34、x+20)
- refactor: 時計を HH:MM 形式に (秒削除、他は b77f3bd の状態)
- refactor: 時計を控えめ表示に (HH:MM 右寄せ、アイコン・枠なし)
- fix: 時計フォントサイズを他行と揃える (34→40)
- feat: 右パネル 4 行目に時計を追加 (HH:MM:SS)
- refactor: Row 0 撤去、右パネルを 3 行に (ECO / TRIP / OIL)
- refactor: Row 0 を RPM 上昇幅 (rpm/s) に変更 + ECO 色を元の仕様に戻す
- fix: エンブレ・アイドル離脱時の戻りを即時化 (snap)
- fix: 情報不足時の Row 0 三角形を白に統一 (ECO 累積行と揃える)
- refactor: Row 0 EMA を状態別 TC + アイドル/エンブレも動的表示 + 色 6 段階に統一
- refactor: Row 0 の色を 5 段階に、黄は停車・アイドル専用に予約
- feat: Row 0 を瞬間燃費表示に変更 + 三角形で累積比較を可視化
- feat: 右パネルを TCC%/ECO/TRIP/OIL に再構成 + ECO 色をトレンドベースに
- feat: OBD2 で燃料残量 (PID 0x2F) と外気温 (PID 0x46) も取得
- feat: 燃費精度検証ログ (Pi avg_fuel_economy を GAS 給油記録に蓄積)
- feat: 平均燃費表示を小数点 2 桁に拡張
- revert: CAN HAT listen-only を OFF に (MAP/MAF が取れないため)
- feat: CAN HAT listen-only モード + README disclaimer 追記
- fix: GAS Webhook URL を git 管理から除外
- fix: ローカルデプロイの確実な反映 + auto-update を起動時のみに
- feat: LOCK SLIP を緑点滅で表現 + 不明ギア表示を -- に統一
- feat: TCC スリップロック検出 + drive-test 修正 + Range 表記改善
- fix: mapKpa スコープ修正 (ECO色計算で参照エラー→右パネル全死)
- fix: バキューム計 ACC→ON 最大値張り付き + 消灯色を青に
- fix: バキューム計針のオープニング時黒表示を修正 (#333→#78909c)
- feat: auto-update 後にフロント自動リロード (バージョン検知)
- fix: RPM針の消灯時黒表示を修正 (offColor #222→#78909c)
- fix: 速度0kmで値が黒になる問題 + 目盛りフォント調整
- fix: orphan cog 問題 + auto-update stable で web/static 未更新の修正
- feat: タコメーター中心レイアウトに変更
- fix: gofmt 適用
- docs: v1.1.0 リリース前ドキュメント更新
- feat: 大数値3箇所にオフセット影 + demo データ範囲拡大
- feat: 枠要素に bloom 追加 + インナーリング明度調整
- feat: アーク bloom 幅広化 + clone 方式統一
- feat: 針の残像 bloom + ACC 全体消灯 + demo モード競合解消
- feat: クライアントエラー/フリーズ検知ログ + オープニング Phase 3 + OBD 未接続プレースホルダー
- Revert "Merge pull request #108 from RyoheiHashimoto/feature/sdl-revival"
- chore: go mod tidy for SDL deps
- feat(sdl): SDL 版復活 第1段階 - main.go / CI / deps
- chore: SDL 版復活用ブランチ作成
- fix: SSH ロックアウト復旧コードを起動時に実行
- feat: fake bloom で全要素を発光化 + 多層ベゼル
- feat: SVGフィルタでグロー強化 + メタリックベゼル + ガラス反射
- feat: Wayland/WPE キオスク移行 + 白フラッシュ解消
- fix: バキューム中心グラデ明るく + ガラスパネル色調整
- feat: ブラウザ版デザイン大幅改善
- feat: SDL2 直描画を廃止、ブラウザ版に一本化
- feat: ブラウザ版にSDL版のデザイン改善を移植
- perf: アーク polyline ステップ数を 1/3 に削減 (1.5→0.5 per degree)
- debug: アーク・針の描画時間計測を追加（60フレームごとにログ出力）
- revert: グロー4層・毎フレーム描画・60fps vsync に戻す
- chore: 未使用の dirty tracking フィールド削除
- perf: グロー4層→1層に軽量化 + 60fps vsync 復帰
- perf: アーク・針の角度ベース dirty tracking で CPU ラスタライズ削減
- perf: 30fps フレームレート制限 + vsync 除去
- fix: LERP を delta time ベースに変更（フレームレート非依存）
- fix: lint エラー修正 (gofmt, staticcheck, unused)
- fix: gofmt + errcheck lint エラー修正
- chore: go mod tidy
- chore: 未使用の定数・色変数を削除
- feat: 右下インジケーターにガラスパネル + バキューム中心グラデ明るく
- feat: 速度/RPM/バキューム数値にドロップシャドウ + 同心円ガイドライン
- feat: 速度・RPM 色閾値を ZJ-VE / DYデミオの実用域に最適化
- fix: バキューム計の目盛りをインナーリングの上に描画
- feat: SDL版メーター用 systemd サービス + セットアップスクリプト + CI 更新
- feat: ラジアルグラデーション背景・立体トラック・起動プレースホルダー
- feat: sdlui を canvas ベースに全面書き換え + 起動アニメーション
- feat: tdewolff/canvas プロトタイプ (速度計/バキューム計/インジケーター)
- fix: OIL表示を残りkmから交換後走行kmに変更
- fix: SDLモードでOBDデータ処理ループが動作しないバグを修正
- fix: 右パネル位置をブラウザ版に合わせる + 目盛りラベル修正
- fix: グロー大幅強化 + 丸キャップ + RPMカンマ区切り + ギア枠色つき
- fix: フォントキャッシュ LRU 化 + グロー軽減 + 静的テクスチャ左パネル限定
- fix: throttle バリデーション上限を 255 に修正（CAN LOAD 生値対応）
- fix: メインループの GAS 送信を goroutine 化してフリーズ防止 (#99)
- feat: SDL2 Phase 2 — 全ゲージ + 右パネル + 3秒長押し終了 (#97)
- feat: SDL2 Phase 1 — 基盤 + 速度ゲージ + デモモード (#96)
- docs: v1.0.6 に合わせてドキュメント全面更新
- fix: THROTTLE idle=1 + dimZone=5（アイドル時のピョコ防止）
- fix: THROTTLE dimZone を 10 に拡大
- fix: THROTTLE dimZone + ECO 色を VACUUM 同期
- fix: VACUUM ラベルの赤色も #f44336 に統一
- feat: バキューム計化 + VACUUM ラベル + 赤色統一
- fix: エンブレ判定 MAP 閾値を 35→30 kPa に変更
- feat: WebSocket リアルタイム配信 (#57)
- fix: メーター微調整 — 目盛り・数値位置・スロットル径
- fix: MAP アーク幅を 10px に統一（スロットル/RPM と揃える）
- fix: スロットル max を CAN LOAD 実測値 197 に合わせる
- fix: HOLD/LOCK 24px化 + ギア/レンジ グロー復活
- feat: 右パネル刷新 — MAP メーター + 4行インジケーター化
- tool: 実走テスト用スクリーンショット定期キャプチャスクリプト
- perf: HTTP ポーリング間隔を 50ms に戻す（CAN 直結対応）
- feat: GAS ダッシュボードを OIL 専用化 + docs 更新
- feat: 右パネル2連メーター化 + OIL専用メンテ + ECOグラデーション + 各種config化
- fix: TCC ロック判定を 0x231 B1 bit4 に修正
- revert: 3連メーター統合直後の状態に戻す
- revert: 3連メーター統合を全て元に戻す
- perf: ポーリング間隔 50ms→200ms + グロー復元
- perf: 全 drop-shadow 無効化 + 無変更時のRAF起動スキップ
- perf: 3連メーターの drop-shadow 全削除 — Pi GPU負荷軽減
- fix: トースト削除 + 3連メーターLERP高速化 (0.35→0.7)
- feat: 3連メーター + 警告灯を本番 meter.html に統合
- fix: CI lint エラー修正 — errcheck + gofmt
- docs: 実走テスト計画 — ギア比オーバーフロー検証 + TC ロック条件
- docs: CAN ギア比解析ドキュメント — 0x230 B2 オーバーフロー問題と解決
- docs: CLAUDE.md 更新 — 右パネル3連メーター・警告灯・CAN B2オーバーフロー
- fix: 0x230 B2 ギア比の1バイトオーバーフロー対応 (#80)
- feat: ギア比メーター色モード + P色変更 + CHECK警告灯
- feat: CHECK警告灯追加 + ギア比メーターの色設計確定
- feat: 3連メーター確定 — GEAR/MAP+AF/PS+TQ + フォント調整
- feat: 警告灯の並び順確定 + メンテ項目追加 + AC→AC.F
- feat: 警告灯システム — severity/alertLevel + メンテ項目拡充
- feat: 右パネル 3連二重アークメーター プロトタイプ + config追加
- feat: TRIP/ECO 色分け + タンク容量修正
- feat: メーター UI 調整 — 下部インジケーター + アイコン + 色分け
- feat: ギア/レンジインジケーターをメーター左上右上に配置
- feat: CAN パッシブ AT 制御データ + 全 OBD PID 追加
- fix: CAN未接続時もUIに切断状態を通知（ACC時フリーズ修正）
- feat: CAN直結モード (SocketCAN) + リーダー自動復帰 + MAP/LOAD実走ドキュメント
- feat: TRIP閾値をconfig.jsonで直接設定可能に
- fix: キオスク起動前にWiFi接続を待機（ループ）
- fix: キオスク終了後10秒で自動復帰 (Restart=always)
- fix: WiFiガードを削除してキオスク常時起動に変更
- feat: ECOランプ改善 — エンブレ=緑、>=6黄、<6赤 + オレンジを黄色に変更
- fix: 給油後トリップリセット不具合修正 + ELM327 panic修正
- feat: ECO閾値をconfig化 + TEMP閾値調整
- fix: ineffassign lint error blocking CI deploy
- fix: CAN キャプチャ保存先を /opt に変更
- fix: CAN キャプチャスクリプトの初期化とフィルタ修正
- feat: CAN キャプチャスクリプト + テスト手順書
- refactor: 冗長なfuelRateLH<0.01エンブレ判定を削除
- docs: ECO閾値ドキュメントを現行ロジックに更新
- fix: ECO橙/赤閾値を緩和 (10→6.2 km/L) + JS fallback統一
- fix: GASトリップ補正UX改善 + メーターフリーズ防止
- fix: ECO閾値調整 — green≥15/orange≥5/red<5 + エンブレ緑に戻す
- fix: Pi→GAS トリップ同期 — trip_km をペイロードに追加
- fix: GASからトリップ距離復元 + ドキュメント更新
- feat: ECO表示改善 — ReadFast即時判定・エンブレ消灯・UI簡素化
- feat: ELM327接続改善 — タイムアウト追加・ReadFast 2PID化・200msポーリング
- docs: メーター表示指標ガイドを追加
- ui: トリップ補正をメンテの上に移動 + ボタン色入れ替え
- feat: トリップ補正機能（リセット→補正に変更） #51
- test: カバレッジ強化（app.go, sender, trip）
- fix: obd_loop_test.go のlintエラー修正（未使用モック削除・ineffassign解消）
- refactor: OBD読み取りをgoroutine+channelに分離 (#37)
- ci: Claude Code Review ワークフロー削除
- feat: Claude Code Review を実用的なゲートに改善
- fix: Claude Code Review に actions/checkout ステップ追加
- fix: release.sh の自動バージョン計算を全タグ対象に修正
- fix: reader_test.go の gofmt フォーマット修正
- fix: Claude Code Review に id-token: write パーミッション追加
- feat: ダッシュボードに走行統計カード + トリップリセット機能追加
- test: obd Readerテスト追加 + GAS給油ログの未使用カラム削除
- fix: release.sh で必須チェックのみ待機（--required）
- fix: release.sh が dev-latest タグを拾う問題を修正
- ci: リリース戦略改善 — 冪等スクリプト・PRリリースノート・Pi自動ロールバック
- refactor: コード品質改善 — ArcAnimator抽出・obdState構造体化・errcheck導入
- docs: ドキュメント全面整備 — 実態との乖離修正 + 構造分割
- docs: キオスク終了を「画面3秒長押し」に修正
- ci: mainブランチ保護 + PRベースリリースフロー
- docs: Wi-Fiトラブルシューティングガイド追加
- ci: CI成功時のみdevデプロイを実行
- feat: RPMインジケーター追加 + gofmtエラー修正
- feat: RPMインジケーター追加（SEND削除）
- feat: MAP・燃料レートアーク追加 + UI改善
- feat: インマニ圧(MAP)センサー対応 — 表示・燃費推定・エンブレ判定
- fix: configバリデーション・ヘルスチェック強化・テスト拡充・ログ改善
- chore: 不要コード削除 + ドキュメント更新
- refactor: EMA平滑化を全て除去し生値を使用（スパイク除去は維持）
- fix: 燃費表示の精度改善 — レート補正係数追加・EMA修正・速度0表示
- fix: シミュレーションモードがAPI復帰後も停止しない問題を修正
- perf: メーターUI応答性改善 — LERP速度・CSS遷移を高速化
- fix: トリップ状態保存を距離ベース(0.1km)に変更し電源断での距離ロスを低減
- fix: スロットルアークのスケーリング修正（ベタ踏みで最大到達）
- refactor: 車種依存の閾値をconfig化・排気量連動化
- fix: OBD全値にスパイク除去+EMA平滑化フィルター追加
- feat: タッチパネルからキオスク終了 + WiFi未接続時キオスク抑止
- feat: Claude Codeスキル追加 + 燃費EMAスムージング + ポーリング200ms復帰
- docs: 算出ロジック・閾値一覧を追加
- feat: Pi自動デプロイ（develop push → 2分以内に自動更新）
- ci: GASデプロイをdevelopブランチでも実行
- fix: エンブレ判定改善 + ECO>30で平均燃費表示 + TEMP閾値変更
- feat: develop/mainブランチ戦略を導入
- fix: golangci-lint v2移行（CI Go 1.25対応）

---
Auto-generated by `make release`